### PR TITLE
#8 [FEATURE] 프로필 관련 기능 구현 : 공통

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 application.yml
+application-dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 
 application.yml
 application-dev.yml
+
+# Querydsl
+/target/generated-sources/
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 
 	// modelMapper
 	implementation 'org.modelmapper:modelmapper:3.0.0'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/mfc/memberservice/common/config/QueryDslConfig.java
+++ b/src/main/java/com/mfc/memberservice/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.mfc.memberservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/mfc/memberservice/common/config/SecurityConfig.java
+++ b/src/main/java/com/mfc/memberservice/common/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
 				.csrf(AbstractHttpConfigurer::disable)
 				.formLogin(AbstractHttpConfigurer::disable)
 				.authorizeHttpRequests((auth) -> auth
-						.requestMatchers("/auth/**")
+						.requestMatchers("/**")
 						.permitAll()
 						.anyRequest()
 						.authenticated()

--- a/src/main/java/com/mfc/memberservice/common/exception/BaseExceptionHandler.java
+++ b/src/main/java/com/mfc/memberservice/common/exception/BaseExceptionHandler.java
@@ -28,7 +28,7 @@ public class BaseExceptionHandler {
 		return new ResponseEntity<>(response, response.httpStatus());
 	}
 
-	@ExceptionHandler(Exception.class)
+	// @ExceptionHandler(Exception.class)
 	public ResponseEntity<?> handleAllExceptions(Exception e) {
 		BaseResponse<?> response = new BaseResponse<>(e.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/mfc/memberservice/common/exception/BaseExceptionHandler.java
+++ b/src/main/java/com/mfc/memberservice/common/exception/BaseExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.mfc.memberservice.common.exception;
 
+import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -25,6 +28,17 @@ public class BaseExceptionHandler {
 	@ExceptionHandler
 	public ResponseEntity<?> incorrectPassword(BadCredentialsException e) { // 비밀번호 불일치
 		BaseResponse<?> response = new BaseResponse<>(BaseResponseStatus.FAILED_TO_LOGIN);
+		return new ResponseEntity<>(response, response.httpStatus());
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<BaseResponse<String>> processValidationError(MethodArgumentNotValidException e) {
+		String errors = e.getBindingResult().getFieldErrors().stream()
+				.map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+				.collect(Collectors.joining(", "));
+
+		BaseResponse<String> response = new BaseResponse<>(HttpStatus.BAD_REQUEST, false, errors, 400, null);
+
 		return new ResponseEntity<>(response, response.httpStatus());
 	}
 

--- a/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
@@ -27,7 +27,7 @@ public enum BaseResponseStatus {
 	MESSAGE_VALID_FAILED(HttpStatus.UNAUTHORIZED, false, 401, "인증번호가 일치하지 않습니다."),
 	FAILED_TO_LOGIN(HttpStatus.UNAUTHORIZED, false, 401, "아이디 또는 패스워드를 다시 확인하세요."),
 	WITHDRAWAL_MEMBERS(HttpStatus.FORBIDDEN, false, 2105, "탈퇴한 회원입니다."),
-	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 2112, "올바르지 않은 역할입니다."),
+	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 2112, "잘못된 접근입니다."),
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다.");
 
 	private final HttpStatusCode httpStatusCode;

--- a/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
@@ -27,8 +27,10 @@ public enum BaseResponseStatus {
 	MESSAGE_VALID_FAILED(HttpStatus.UNAUTHORIZED, false, 401, "인증번호가 일치하지 않습니다."),
 	FAILED_TO_LOGIN(HttpStatus.UNAUTHORIZED, false, 401, "아이디 또는 패스워드를 다시 확인하세요."),
 	WITHDRAWAL_MEMBERS(HttpStatus.FORBIDDEN, false, 2105, "탈퇴한 회원입니다."),
-	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 2112, "잘못된 접근입니다."),
+	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다."),
+	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다.");
+
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;

--- a/src/main/java/com/mfc/memberservice/member/application/MemberService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberService.java
@@ -1,0 +1,7 @@
+package com.mfc.memberservice.member.application;
+
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+
+public interface MemberService {
+	ProfileRespDto getProfile(String uuid, String role);
+}

--- a/src/main/java/com/mfc/memberservice/member/application/MemberService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberService.java
@@ -1,8 +1,10 @@
 package com.mfc.memberservice.member.application;
 
+import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 
 public interface MemberService {
 	ProfileRespDto getProfile(String uuid, String role);
 	void modifyNickname(String uuid, String role, String nickname);
+	void modifyPassword(String uuid, ModifyMemberReqDto dto);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/MemberService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberService.java
@@ -4,4 +4,5 @@ import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 
 public interface MemberService {
 	ProfileRespDto getProfile(String uuid, String role);
+	void modifyNickname(String uuid, String role, String nickname);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -6,8 +6,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.common.response.BaseResponse;
+import com.mfc.memberservice.member.domain.Partner;
+import com.mfc.memberservice.member.domain.User;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.infrastructure.MemberRepository;
+import com.mfc.memberservice.member.infrastructure.PartnerRepository;
+import com.mfc.memberservice.member.infrastructure.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class MemberServiceImpl implements MemberService {
 	private final MemberRepository memberRepository;
+	private final UserRepository userRepository;
+	private final PartnerRepository partnerRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -35,5 +42,48 @@ public class MemberServiceImpl implements MemberService {
 		}
 
 		return profile;
+	}
+
+	@Override
+	public void modifyNickname(String uuid, String role, String nickname) {
+		if(role.equals("USER")) {
+			User user = userRepository.findByUuid(uuid)
+					.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+			updateUserNickname(user, nickname);
+
+		} else if(role.equals("PARTNER")) {
+			Partner partner = partnerRepository.findByUuid(uuid)
+					.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+			updatePartnerNickname(partner, nickname);
+		} else {
+			throw new BaseException(NO_EXIT_ROLE);
+		}
+	}
+
+	private void updateUserNickname(User user, String nickname) {
+		userRepository.save(User.builder()
+				.id(user.getId())
+				.nickname(nickname)
+				.profileImage(user.getProfileImage())
+				.topSize(user.getTopSize())
+				.height(user.getHeight())
+				.imageAlt(user.getImageAlt())
+				.shoeSize(user.getShoeSize())
+				.bottomSize(user.getBottomSize())
+				.build()
+		);
+	}
+
+	private void updatePartnerNickname(Partner partner, String nickname) {
+		partnerRepository.save(Partner.builder()
+				.id(partner.getId())
+				.nickname(nickname)
+				.profileImage(partner.getProfileImage())
+				.imageAlt(partner.getImageAlt())
+				.average_date(partner.getAverage_date())
+				.description(partner.getDescription())
+				.account(partner.getAccount())
+				.build()
+		);
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -6,11 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
-import com.mfc.memberservice.member.domain.User;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.infrastructure.MemberRepository;
-import com.mfc.memberservice.member.infrastructure.PartnerRepository;
-import com.mfc.memberservice.member.infrastructure.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,23 +16,24 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class MemberServiceImpl implements MemberService {
 	private final MemberRepository memberRepository;
-	private final UserRepository userRepository;
-	private final PartnerRepository partnerRepository;
 
 	@Override
 	@Transactional(readOnly = true)
 	public ProfileRespDto getProfile(String uuid, String role) {
-		if(role.equals("user")) {
-			User user = userRepository.findByUuid(uuid)
-					.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
-			return null;
+		ProfileRespDto profile = null;
 
-
-		} else if(role.equals("partner")) {
-			return null;
-
+		if(role.equals("USER")) {
+			profile = memberRepository.getUserProfile(uuid);
+		} else if(role.equals("PARTNER")) {
+			profile = memberRepository.getPartnerProfile(uuid);
 		} else {
 			throw new BaseException(NO_EXIT_ROLE);
 		}
+
+		if(profile == null) {
+			throw new BaseException(MEMBER_NOT_FOUND);
+		}
+
+		return profile;
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -1,0 +1,41 @@
+package com.mfc.memberservice.member.application;
+
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+import com.mfc.memberservice.member.infrastructure.MemberRepository;
+import com.mfc.memberservice.member.infrastructure.PartnerRepository;
+import com.mfc.memberservice.member.infrastructure.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberServiceImpl implements MemberService {
+	private final MemberRepository memberRepository;
+	private final UserRepository userRepository;
+	private final PartnerRepository partnerRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public ProfileRespDto getProfile(String uuid, String role) {
+		if(role.equals("user")) {
+			User user = userRepository.findByUuid(uuid)
+					.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+			return null;
+
+
+		} else if(role.equals("partner")) {
+			return null;
+
+		} else {
+			throw new BaseException(NO_EXIT_ROLE);
+		}
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -2,13 +2,16 @@ package com.mfc.memberservice.member.application;
 
 import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
+import com.mfc.memberservice.member.domain.Member;
 import com.mfc.memberservice.member.domain.Partner;
 import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.infrastructure.MemberRepository;
 import com.mfc.memberservice.member.infrastructure.PartnerRepository;
@@ -23,6 +26,8 @@ public class MemberServiceImpl implements MemberService {
 	private final MemberRepository memberRepository;
 	private final UserRepository userRepository;
 	private final PartnerRepository partnerRepository;
+
+	private final PasswordEncoder encoder;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -58,6 +63,20 @@ public class MemberServiceImpl implements MemberService {
 		} else {
 			throw new BaseException(NO_EXIT_ROLE);
 		}
+	}
+
+	@Override
+	public void modifyPassword(String uuid, ModifyMemberReqDto dto) {
+		Member member = memberRepository.findByUuid(uuid)
+				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+
+		memberRepository.save(Member.builder()
+				.id(member.getId())
+				.password(encoder.encode(dto.getPassword()))
+				.role(member.getRole())
+				.build()
+		);
+
 	}
 
 	private void updateUserNickname(User user, String nickname) {

--- a/src/main/java/com/mfc/memberservice/member/domain/Member.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/Member.java
@@ -29,17 +29,19 @@ public class Member extends BaseEntity implements UserDetails {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Column(updatable = false)
 	private String uuid;
-	@Column(nullable = false, length = 20)
+	@Column(nullable = false, length = 20, updatable = false)
 	private String email;
 	@Column(nullable = false)
 	private String password;
 	@Column(nullable = false, updatable = false, length = 10)
 	private String name;
-	@Column(nullable = false)
+	@Column(nullable = false, updatable = false)
 	private String phone;
+	@Column(updatable = false)
 	private LocalDate birth;
-	@Column(columnDefinition = "TINYINT")
+	@Column(columnDefinition = "TINYINT", updatable = false)
 	private Short gender;
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)

--- a/src/main/java/com/mfc/memberservice/member/domain/Partner.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/Partner.java
@@ -24,17 +24,20 @@ public class Partner extends BaseEntity {
 	@Column(nullable = false, length = 20)
 	private String nickname;
 	private String profileImage;
+	@Column(length = 50)
+	private String imageAlt;
 	private String account;
 	private String description;
 	private Integer average_date;
 
 	@Builder
 	public Partner(Long id, String uuid, String nickname, String profileImage, String account, String description,
-			Integer average_date) {
+			Integer average_date, String imageAlt) {
 		this.id = id;
 		this.uuid = uuid;
 		this.nickname = nickname;
 		this.profileImage = profileImage;
+		this.imageAlt = imageAlt;
 		this.account = account;
 		this.description = description;
 		this.average_date = average_date;

--- a/src/main/java/com/mfc/memberservice/member/domain/Partner.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/Partner.java
@@ -20,6 +20,7 @@ public class Partner extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Column(updatable = false)
 	private String uuid;
 	@Column(nullable = false, length = 20)
 	private String nickname;

--- a/src/main/java/com/mfc/memberservice/member/domain/User.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/User.java
@@ -18,8 +18,9 @@ public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Column(updatable = false)
 	private String uuid;
-	@Column(nullable = false, length = 10)
+	@Column(nullable = false, length = 20)
 	private String nickname;
 	private String profileImage;
 	@Column(length = 50)

--- a/src/main/java/com/mfc/memberservice/member/domain/User.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/User.java
@@ -1,7 +1,5 @@
 package com.mfc.memberservice.member.domain;
 
-import java.util.UUID;
-
 import com.mfc.memberservice.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -24,6 +22,8 @@ public class User extends BaseEntity {
 	@Column(nullable = false, length = 10)
 	private String nickname;
 	private String profileImage;
+	@Column(length = 50)
+	private String imageAlt;
 	private Integer height;
 	@Column(length = 20)
 	private String topSize;
@@ -33,12 +33,12 @@ public class User extends BaseEntity {
 
 	@Builder
 	public User(Long id, String uuid, String nickname, String profileImage, Integer height, String topSize,
-			String bottomSize,
-			Integer shoeSize) {
+			String bottomSize, Integer shoeSize, String imageAlt) {
 		this.id = id;
 		this.uuid = uuid;
 		this.nickname = nickname;
 		this.profileImage = profileImage;
+		this.imageAlt = imageAlt;
 		this.height = height;
 		this.topSize = topSize;
 		this.bottomSize = bottomSize;

--- a/src/main/java/com/mfc/memberservice/member/dto/req/ModifyMemberReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/ModifyMemberReqDto.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyMemberReqDto {
+	private String password;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
@@ -1,24 +1,13 @@
 package com.mfc.memberservice.member.dto.resp;
 
-import com.mfc.memberservice.member.domain.User;
-
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class ProfileRespDto {
 	private String profileImage;
 	private String imageAlt;
 	private String nickname;
 	private String email;
-
-	public static ProfileRespDto toUser(User user) {
-		return ProfileRespDto.builder()
-				.profileImage(user.getProfileImage())
-				.imageAlt(user.getImageAlt())
-				.email(user.getUuid())
-				.nickname(user.getNickname())
-				.build();
-	}
 }

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
@@ -1,0 +1,24 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import com.mfc.memberservice.member.domain.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileRespDto {
+	private String profileImage;
+	private String imageAlt;
+	private String nickname;
+	private String email;
+
+	public static ProfileRespDto toUser(User user) {
+		return ProfileRespDto.builder()
+				.profileImage(user.getProfileImage())
+				.imageAlt(user.getImageAlt())
+				.email(user.getUuid())
+				.nickname(user.getNickname())
+				.build();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/CustomMemberRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/CustomMemberRepository.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.infrastructure;
+
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+
+public interface CustomMemberRepository {
+	ProfileRespDto getUserProfile(String uuid);
+	ProfileRespDto getPartnerProfile(String uuid);
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/CustomMemberRepositoryImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/CustomMemberRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.mfc.memberservice.member.infrastructure;
+
+import static com.mfc.memberservice.member.domain.QMember.*;
+import static com.mfc.memberservice.member.domain.QPartner.*;
+import static com.mfc.memberservice.member.domain.QUser.*;
+
+import com.mfc.memberservice.member.domain.QPartner;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomMemberRepositoryImpl implements CustomMemberRepository {
+	private final JPAQueryFactory query;
+
+	@Override
+	public ProfileRespDto getUserProfile(String uuid) {
+		return query
+				.select(Projections.constructor(ProfileRespDto.class,
+						user.profileImage.as("profileImage"),
+						user.imageAlt.as("imageAlt"),
+						user.nickname.as("nickname"),
+						member.email.as("email")
+				))
+				.from(user)
+				.join(member)
+				.on(user.uuid.eq(member.uuid))
+				.where(user.uuid.eq(uuid))
+				.fetchOne();
+	}
+
+	@Override
+	public ProfileRespDto getPartnerProfile(String uuid) {
+		return query
+				.select(Projections.constructor(ProfileRespDto.class,
+						partner.profileImage.as("profileImage"),
+						partner.imageAlt.as("imageAlt"),
+						partner.nickname.as("nickname"),
+						member.email.as("email")
+				))
+				.from(partner)
+				.join(member)
+				.on(partner.uuid.eq(member.uuid))
+				.where(partner.uuid.eq(uuid))
+				.fetchOne();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mfc.memberservice.member.domain.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, CustomMemberRepository {
 	Optional<Member> findByPhone(String phone);
 	Optional<Member> findByUuid(String uuid);
 	Optional<Member> findByEmail(String email);

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/PartnerRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/PartnerRepository.java
@@ -9,4 +9,5 @@ import com.mfc.memberservice.member.domain.User;
 
 public interface PartnerRepository extends JpaRepository<Partner, Long> {
 	Optional<Partner> findByNickname(String nickname);
+	Optional<Partner> findByUuid(String Uuid);
 }

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/UserRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/UserRepository.java
@@ -8,4 +8,5 @@ import com.mfc.memberservice.member.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByNickname(String nickname);
+	Optional<User> findByUuid(String uuid);
 }

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -6,16 +6,17 @@ import java.util.List;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
-import com.mfc.memberservice.common.response.BaseResponseStatus;
 import com.mfc.memberservice.member.application.MemberService;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqDto;
 import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
 
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,21 @@ public class MemberController {
 
 		return new BaseResponse<>(modelMapper.map(
 				memberService.getProfile(uuid.get(0), role.get(0)), ProfileRespVo.class));
+	}
+
+	@PutMapping("/nickname")
+	public BaseResponse<Void> modifyNickname(@RequestHeader HttpHeaders header,
+			@RequestBody ModifyUserReqDto dto) {
+		List<String> uuid = header.get("UUID");
+		List<String> role = header.get("Role");
+
+		log.info("nickname={}", dto.getNickname());
+
+		if(uuid == null || role == null) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		memberService.modifyNickname(uuid.get(0), role.get(0), dto.getNickname());
+		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,7 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.application.MemberService;
-import com.mfc.memberservice.member.vo.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
+import com.mfc.memberservice.member.vo.req.ModifyMemberReqVo;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
 
 import lombok.RequiredArgsConstructor;
@@ -45,17 +49,30 @@ public class MemberController {
 
 	@PutMapping("/nickname")
 	public BaseResponse<Void> modifyNickname(@RequestHeader HttpHeaders header,
-			@RequestBody ModifyUserReqDto dto) {
+			@RequestBody ModifyUserReqVo vo) {
 		List<String> uuid = header.get("UUID");
 		List<String> role = header.get("Role");
 
-		log.info("nickname={}", dto.getNickname());
+		log.info("nickname={}", vo.getNickname());
 
 		if(uuid == null || role == null) {
 			throw new BaseException(NO_REQUIRED_HEADER);
 		}
 
-		memberService.modifyNickname(uuid.get(0), role.get(0), dto.getNickname());
+		memberService.modifyNickname(uuid.get(0), role.get(0), vo.getNickname());
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/password")
+	public BaseResponse<Void> modifyPassword(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated ModifyMemberReqVo vo) {
+
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		memberService.modifyPassword(uuid, modelMapper.map(vo, ModifyMemberReqDto.class));
 		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -1,0 +1,22 @@
+package com.mfc.memberservice.member.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.memberservice.common.response.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+	@GetMapping
+	public BaseResponse<?> getProfile(@RequestHeader("UUID") String uuid,
+			@RequestHeader("Role") String role) {
+		return new BaseResponse<>();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -1,22 +1,44 @@
 package com.mfc.memberservice.member.presentation;
 
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import java.util.List;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
+import com.mfc.memberservice.common.response.BaseResponseStatus;
+import com.mfc.memberservice.member.application.MemberService;
+import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
+	private final MemberService memberService;
+	private final ModelMapper modelMapper;
 
 	@GetMapping
-	public BaseResponse<?> getProfile(@RequestHeader("UUID") String uuid,
-			@RequestHeader("Role") String role) {
-		return new BaseResponse<>();
+	public BaseResponse<ProfileRespVo> getProfile(@RequestHeader HttpHeaders header) {
+		List<String> uuid = header.get("UUID");
+		List<String> role = header.get("Role");
+
+		if(uuid == null || role == null) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		return new BaseResponse<>(modelMapper.map(
+				memberService.getProfile(uuid.get(0), role.get(0)), ProfileRespVo.class));
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyMemberReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyMemberReqVo.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.vo.req;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ModifyMemberReqVo {
+	@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[~!@#$%^&*()])[A-Za-z\\d~!@#$%^&*()]{8,20}$",
+		message = "비밀번호는 영대소문자, 숫자, 특수문자를 1개 이상 포함해야 하며, 8~20자여야 합니다.")
+	private String password;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqDto.java
@@ -1,0 +1,14 @@
+package com.mfc.memberservice.member.vo.req;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyUserReqDto {
+	private String nickname;
+	private String profileImage;
+	private String imageAlt;
+	private Integer height;
+	private String topSize;
+	private String bottomSize;
+	private Integer shoeSize;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqVo.java
@@ -3,7 +3,7 @@ package com.mfc.memberservice.member.vo.req;
 import lombok.Getter;
 
 @Getter
-public class ModifyUserReqDto {
+public class ModifyUserReqVo {
 	private String nickname;
 	private String profileImage;
 	private String imageAlt;

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/ProfileRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/ProfileRespVo.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileRespVo {
+	private String profileImage;
+	private String imageAlt;
+	private String nickname;
+	private String email;
+}


### PR DESCRIPTION
## 📣프로필 관련 공통 기능 구현
### 📅 2024.05.20
 
 ### 🌵Branch
`feature/profile`  → `develop`

### 📢 Description
- Querydsl 설정 추가
- validation dependencies 추가 + 검증 예외 처리 핸들러 추가
- 닉네임 수정 : 헤더의 `role`을 사용하여 회원/파트너 구분
- 기본 프로필 (닉네임, 이메일, 프로필 사진) 조회  : 헤더의 `role`을 사용하여 회원/파트너 구분
- 비밀번호 수정 : 회원/파트너 공통

### 💬Issue Number
[#8 ] - 프로필 관련 기능 구현 (공통)

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [x] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [x] 빌드 부분 혹은 패키지 매니저 수정 
- [x] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
- 화면 설계서 기반으로 유저와 파트너가 같은 페이지를 사용하는 경우, 하나의 API와 헤더의 `role`을 사용하여 구분하도록 구현하였습니다!