### PR TITLE
#9 [FEATURE] 프로필 관련 기능 구현 : 유저

### DIFF
--- a/src/main/java/com/mfc/memberservice/member/application/MemberService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.mfc.memberservice.member.application;
 
+import com.mfc.memberservice.member.dto.req.ModifyFavoriteStyleReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 
@@ -7,4 +8,5 @@ public interface MemberService {
 	ProfileRespDto getProfile(String uuid, String role);
 	void modifyNickname(String uuid, String role, String nickname);
 	void modifyPassword(String uuid, ModifyMemberReqDto dto);
+	void modifyFavoriteStyle(String uuid, ModifyFavoriteStyleReqDto dto);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -11,11 +11,14 @@ import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.domain.Member;
 import com.mfc.memberservice.member.domain.Partner;
 import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.dto.req.ModifyFavoriteStyleReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.infrastructure.MemberRepository;
 import com.mfc.memberservice.member.infrastructure.PartnerRepository;
 import com.mfc.memberservice.member.infrastructure.UserRepository;
+import com.mfc.memberservice.style.domain.FavoriteStyle;
+import com.mfc.memberservice.style.infrastructure.FavoriteStyleRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +29,7 @@ public class MemberServiceImpl implements MemberService {
 	private final MemberRepository memberRepository;
 	private final UserRepository userRepository;
 	private final PartnerRepository partnerRepository;
+	private final FavoriteStyleRepository favoriteStyleRepository;
 
 	private final PasswordEncoder encoder;
 
@@ -76,7 +80,18 @@ public class MemberServiceImpl implements MemberService {
 				.role(member.getRole())
 				.build()
 		);
+	}
 
+	@Override
+	public void modifyFavoriteStyle(String uuid, ModifyFavoriteStyleReqDto dto) {
+		favoriteStyleRepository.deleteByUuid(uuid);
+
+		dto.getFavoriteStyles().stream()
+				.forEach(i -> favoriteStyleRepository.save(
+						FavoriteStyle.builder()
+								.uuid(uuid)
+								.styleId(i)
+								.build()));
 	}
 
 	private void updateUserNickname(User user, String nickname) {

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -90,6 +90,7 @@ public class MemberServiceImpl implements MemberService {
 				.imageAlt(user.getImageAlt())
 				.shoeSize(user.getShoeSize())
 				.bottomSize(user.getBottomSize())
+				.bodyType(user.getBodyType())
 				.build()
 		);
 	}

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -86,6 +86,7 @@ public class MemberServiceImpl implements MemberService {
 				.profileImage(user.getProfileImage())
 				.topSize(user.getTopSize())
 				.height(user.getHeight())
+				.weight(user.getWeight())
 				.imageAlt(user.getImageAlt())
 				.shoeSize(user.getShoeSize())
 				.bottomSize(user.getBottomSize())

--- a/src/main/java/com/mfc/memberservice/member/application/UserService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserService.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.application;
+
+import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+
+public interface UserService {
+	void updateProfile(String uuid, ModifyUserReqDto dto);
+}

--- a/src/main/java/com/mfc/memberservice/member/application/UserService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserService.java
@@ -5,4 +5,7 @@ import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 
 public interface UserService {
 	void updateProfile(String uuid, ModifyUserReqDto dto);
+	void updateSize(String uuid, ModifyUserReqDto dto);
+	void updateProfileImage(String uuid, ModifyUserReqDto dto);
+	void updateBodyType(String uuid, ModifyUserReqDto dto);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
@@ -1,0 +1,41 @@
+package com.mfc.memberservice.member.application;
+
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.infrastructure.UserRepository;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+	private final UserRepository userRepository;
+
+	@Override
+	public void updateProfile(String uuid, ModifyUserReqDto dto) {
+		User user = userRepository.findByUuid(uuid)
+				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+
+		userRepository.save(User.builder()
+				.id(user.getId())
+				.nickname(user.getNickname())
+				.profileImage(user.getProfileImage())
+				.imageAlt(user.getImageAlt())
+				.height(dto.getHeight())
+				.weight(dto.getWeight())
+				.bottomSize(dto.getBottomSize())
+				.topSize(dto.getTopSize())
+				.shoeSize(dto.getShoeSize())
+				.bodyType(dto.getBodyType())
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
@@ -9,7 +9,6 @@ import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.member.domain.User;
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
 import com.mfc.memberservice.member.infrastructure.UserRepository;
-import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,8 +20,7 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public void updateProfile(String uuid, ModifyUserReqDto dto) {
-		User user = userRepository.findByUuid(uuid)
-				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+		User user = isExist(uuid);
 
 		userRepository.save(User.builder()
 				.id(user.getId())
@@ -37,5 +35,67 @@ public class UserServiceImpl implements UserService {
 				.bodyType(dto.getBodyType())
 				.build()
 		);
+	}
+
+	@Override
+	public void updateSize(String uuid, ModifyUserReqDto dto) {
+		User user = isExist(uuid);
+
+		userRepository.save(User.builder()
+				.id(user.getId())
+				.nickname(user.getNickname())
+				.profileImage(user.getProfileImage())
+				.imageAlt(user.getImageAlt())
+				.height(user.getHeight())
+				.weight(user.getWeight())
+				.bottomSize(dto.getBottomSize()) // 수정
+				.topSize(dto.getTopSize()) // 수정
+				.shoeSize(dto.getShoeSize()) // 수정
+				.bodyType(user.getBodyType())
+				.build()
+		);
+	}
+
+	@Override
+	public void updateProfileImage(String uuid, ModifyUserReqDto dto) {
+		User user = isExist(uuid);
+
+		userRepository.save(User.builder()
+				.id(user.getId())
+				.nickname(user.getNickname())
+				.profileImage(dto.getProfileImage()) // 수정
+				.imageAlt("Profile Image") // 수정
+				.height(user.getHeight())
+				.weight(user.getWeight())
+				.bottomSize(user.getBottomSize())
+				.topSize(user.getTopSize())
+				.shoeSize(user.getShoeSize())
+				.bodyType(user.getBodyType())
+				.build()
+		);
+	}
+
+	@Override
+	public void updateBodyType(String uuid, ModifyUserReqDto dto) {
+		User user = isExist(uuid);
+
+		userRepository.save(User.builder()
+				.id(user.getId())
+				.nickname(user.getNickname())
+				.profileImage(user.getProfileImage())
+				.imageAlt(user.getImageAlt())
+				.height(dto.getHeight()) // 수정
+				.weight(dto.getWeight()) // 수정
+				.bottomSize(user.getBottomSize())
+				.topSize(user.getTopSize())
+				.shoeSize(user.getShoeSize())
+				.bodyType(dto.getBodyType()) // 수정
+				.build()
+		);
+	}
+
+	private User isExist(String uuid) {
+		return userRepository.findByUuid(uuid)
+				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/domain/User.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/User.java
@@ -26,6 +26,7 @@ public class User extends BaseEntity {
 	@Column(length = 50)
 	private String imageAlt;
 	private Integer height;
+	private Integer weight;
 	@Column(length = 20)
 	private String topSize;
 	@Column(length = 20)
@@ -33,14 +34,15 @@ public class User extends BaseEntity {
 	private Integer shoeSize;
 
 	@Builder
-	public User(Long id, String uuid, String nickname, String profileImage, Integer height, String topSize,
-			String bottomSize, Integer shoeSize, String imageAlt) {
+	public User(Long id, String uuid, String nickname, String profileImage, Integer height, Integer weight,
+			String topSize, String bottomSize, Integer shoeSize, String imageAlt) {
 		this.id = id;
 		this.uuid = uuid;
 		this.nickname = nickname;
 		this.profileImage = profileImage;
 		this.imageAlt = imageAlt;
 		this.height = height;
+		this.weight = weight;
 		this.topSize = topSize;
 		this.bottomSize = bottomSize;
 		this.shoeSize = shoeSize;

--- a/src/main/java/com/mfc/memberservice/member/domain/User.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/User.java
@@ -32,10 +32,11 @@ public class User extends BaseEntity {
 	@Column(length = 20)
 	private String bottomSize;
 	private Integer shoeSize;
+	private String bodyType;
 
 	@Builder
 	public User(Long id, String uuid, String nickname, String profileImage, Integer height, Integer weight,
-			String topSize, String bottomSize, Integer shoeSize, String imageAlt) {
+			String topSize, String bottomSize, Integer shoeSize, String imageAlt, String bodyType) {
 		this.id = id;
 		this.uuid = uuid;
 		this.nickname = nickname;
@@ -46,5 +47,6 @@ public class User extends BaseEntity {
 		this.topSize = topSize;
 		this.bottomSize = bottomSize;
 		this.shoeSize = shoeSize;
+		this.bodyType = bodyType;
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/dto/req/ModifyFavoriteStyleReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/ModifyFavoriteStyleReqDto.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.dto.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyFavoriteStyleReqDto {
+	private List<Long> favoriteStyles = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/ModifyUserReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/ModifyUserReqDto.java
@@ -1,9 +1,9 @@
-package com.mfc.memberservice.member.vo.req;
+package com.mfc.memberservice.member.dto.req;
 
 import lombok.Getter;
 
 @Getter
-public class ModifyUserReqVo {
+public class ModifyUserReqDto {
 	private String nickname;
 	private String profileImage;
 	private String imageAlt;

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,7 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.application.MemberService;
+import com.mfc.memberservice.member.dto.req.ModifyFavoriteStyleReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyMemberReqDto;
+import com.mfc.memberservice.member.vo.req.ModifyFavoriteStyleReqVo;
 import com.mfc.memberservice.member.vo.req.ModifyMemberReqVo;
 import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
@@ -73,6 +76,19 @@ public class MemberController {
 		}
 
 		memberService.modifyPassword(uuid, modelMapper.map(vo, ModifyMemberReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PostMapping("/favoritestyle")
+	public BaseResponse<Void> modifyStyle(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated ModifyFavoriteStyleReqVo vo) {
+
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		memberService.modifyFavoriteStyle(uuid, modelMapper.map(vo, ModifyFavoriteStyleReqDto.class));
 		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
@@ -1,0 +1,40 @@
+package com.mfc.memberservice.member.presentation;
+
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.common.response.BaseResponse;
+import com.mfc.memberservice.common.response.BaseResponseStatus;
+import com.mfc.memberservice.member.application.UserService;
+import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+	private final ModelMapper modelMapper;
+
+	@PutMapping("/profile")
+	public BaseResponse<Void> updateProfile(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody ModifyUserReqVo vo) {
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		userService.updateProfile(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
+		return new BaseResponse<>();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
@@ -30,11 +30,41 @@ public class UserController {
 	public BaseResponse<Void> updateProfile(
 			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
 			@RequestBody ModifyUserReqVo vo) {
+		checkUuid(uuid);
+		userService.updateProfile(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/size")
+	public BaseResponse<Void> updateSize(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody ModifyUserReqVo vo) {
+		checkUuid(uuid);
+		userService.updateSize(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/profileimage")
+	public BaseResponse<Void> updateProfileImage(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody ModifyUserReqVo vo) {
+		checkUuid(uuid);
+		userService.updateProfileImage(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/bodytype")
+	public BaseResponse<Void> updateBodyType(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody ModifyUserReqVo vo) {
+		checkUuid(uuid);
+		userService.updateBodyType(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	private void checkUuid(String uuid) {
 		if(!StringUtils.hasText(uuid)) {
 			throw new BaseException(NO_REQUIRED_HEADER);
 		}
-
-		userService.updateProfile(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
-		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyFavoriteStyleReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyFavoriteStyleReqVo.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.vo.req;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyFavoriteStyleReqVo {
+	private List<Long> favoriteStyles = new ArrayList<>();
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyUserReqVo.java
@@ -8,6 +8,7 @@ public class ModifyUserReqVo {
 	private String profileImage;
 	private String imageAlt;
 	private Integer height;
+	private Integer weight;
 	private String topSize;
 	private String bottomSize;
 	private Integer shoeSize;

--- a/src/main/java/com/mfc/memberservice/style/domain/FavoriteStyle.java
+++ b/src/main/java/com/mfc/memberservice/style/domain/FavoriteStyle.java
@@ -1,5 +1,6 @@
 package com.mfc.memberservice.style.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,6 +16,7 @@ public class FavoriteStyle {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Column(updatable = false)
 	private String uuid;
 	private Long styleId;
 

--- a/src/main/java/com/mfc/memberservice/style/infrastructure/FavoriteStyleRepository.java
+++ b/src/main/java/com/mfc/memberservice/style/infrastructure/FavoriteStyleRepository.java
@@ -1,8 +1,13 @@
 package com.mfc.memberservice.style.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.mfc.memberservice.style.domain.FavoriteStyle;
 
 public interface FavoriteStyleRepository extends JpaRepository<FavoriteStyle, Long> {
+	@Modifying(clearAutomatically = true)
+	@Query("delete from FavoriteStyle fs where fs.uuid = :uuid")
+	void deleteByUuid(String uuid);
 }


### PR DESCRIPTION
## 📣프로필 관련 기능 구현 : 유저
### 📅2024.05.20
 
 ### 🌵Branch
`feature/profile-user`  → `develop`

### 📢 Description
- User 엔티티 필드 추가 : `weight`, `bodyType`
- 유저 회원가입 후 최초 로그인 시 체형 정보 입력 API
- 유저 정보 수정 API : 프로필 이미지, 사이즈, 신체 정보
- 유저/파트너 공통 API : 선호 스타일 수정

### 💬Issue Number
[#9] - 유저 프로필 관련 기능 구현

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note