### PR TITLE
#11 [FEATURE] 파트너 포트폴리오 관련 API 구현 (1)

### DIFF
--- a/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
@@ -30,7 +30,10 @@ public enum BaseResponseStatus {
 	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다."),
 	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다."),
-	CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 경력입니다.");
+
+	CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 경력입니다."),
+	OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 옵션입니다.");
+
 
 
 	private final HttpStatusCode httpStatusCode;

--- a/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/memberservice/common/response/BaseResponseStatus.java
@@ -29,7 +29,8 @@ public enum BaseResponseStatus {
 	WITHDRAWAL_MEMBERS(HttpStatus.FORBIDDEN, false, 2105, "탈퇴한 회원입니다."),
 	NO_EXIT_ROLE(HttpStatus.BAD_REQUEST, false, 400, "잘못된 접근입니다."),
 	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다."),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다.");
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 회원입니다."),
+	CAREER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 경력입니다.");
 
 
 	private final HttpStatusCode httpStatusCode;

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -1,8 +1,11 @@
 package com.mfc.memberservice.member.application;
 
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
-import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
+import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 
 public interface PartnerService {
 	void updateProfileImage(String uuid, ModifyPartnerReqDto dto);
+	void updateSns(String uuid, UpdateSnsReqDto dto);
+	SnsListRespDto getSnsList(String partnerId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -1,11 +1,17 @@
 package com.mfc.memberservice.member.application;
 
+import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
+import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 
 public interface PartnerService {
 	void updateProfileImage(String uuid, ModifyPartnerReqDto dto);
 	void updateSns(String uuid, UpdateSnsReqDto dto);
 	SnsListRespDto getSnsList(String partnerId);
+	void createCareer(String uuid, CareerReqDto dto);
+	void updateCareer(String uuid, Long careerId, CareerReqDto dto);
+	void deleteCareer(String uuid, Long careerId);
+	CareerListRespDto getCareerList(String partnerId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -2,8 +2,10 @@ package com.mfc.memberservice.member.application;
 
 import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.OptionReqDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
 import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
+import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 
 public interface PartnerService {
@@ -14,4 +16,8 @@ public interface PartnerService {
 	void updateCareer(String uuid, Long careerId, CareerReqDto dto);
 	void deleteCareer(String uuid, Long careerId);
 	CareerListRespDto getCareerList(String partnerId);
+	void createOption(String uuid, OptionReqDto dto);
+	void updateOption(String partnerId, Long optionId, OptionReqDto dto);
+	void deleteOption(String partnerId, Long optionId);
+	OptionListRespDto getOptionList(String partnerId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.application;
+
+import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+
+public interface PartnerService {
+	void updateProfileImage(String uuid, ModifyPartnerReqDto dto);
+}

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -1,0 +1,41 @@
+package com.mfc.memberservice.member.application;
+
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.member.domain.Partner;
+import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.infrastructure.PartnerRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PartnerServiceImpl implements PartnerService {
+	private final PartnerRepository partnerRepository;
+
+	@Override
+	public void updateProfileImage(String uuid, ModifyPartnerReqDto dto) {
+		Partner partner = isExist(uuid);
+
+		partnerRepository.save(Partner.builder()
+				.id(partner.getId())
+				.profileImage(dto.getProfileImage()) // 수정
+				.nickname(partner.getNickname())
+				.imageAlt("Profile Image")
+				.description(partner.getDescription())
+				.account(partner.getAccount())
+				.average_date(partner.getAverage_date())
+				.build());
+	}
+
+	private Partner isExist(String uuid) {
+		return partnerRepository.findByUuid(uuid)
+				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -6,12 +6,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.member.domain.Career;
 import com.mfc.memberservice.member.domain.Partner;
 import com.mfc.memberservice.member.domain.Sns;
+import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
 import com.mfc.memberservice.member.dto.req.SnsDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
+import com.mfc.memberservice.member.dto.resp.CareerDto;
+import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
+import com.mfc.memberservice.member.infrastructure.CareerRepository;
 import com.mfc.memberservice.member.infrastructure.PartnerRepository;
 import com.mfc.memberservice.member.infrastructure.SnsRepository;
 
@@ -23,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class PartnerServiceImpl implements PartnerService {
 	private final PartnerRepository partnerRepository;
 	private final SnsRepository snsRepository;
+	private final CareerRepository careerRepository;
 
 	@Override
 	public void updateProfileImage(String uuid, ModifyPartnerReqDto dto) {
@@ -58,6 +64,50 @@ public class PartnerServiceImpl implements PartnerService {
 				.sns(snsRepository.findByPartnerId(partnerId)
 						.stream()
 						.map(SnsDto::new)
+						.toList())
+				.build();
+	}
+
+	@Override
+	public void createCareer(String uuid, CareerReqDto dto) {
+		isExist(uuid);
+		careerRepository.save(Career.builder()
+				.partnerId(uuid)
+				.title(dto.getTitle())
+				.description(dto.getDescription())
+				.startDate(dto.getStartDate())
+				.finishDate(dto.getFinishDate())
+				.build()
+		);
+	}
+
+	@Override
+	public void updateCareer(String uuid, Long careerId, CareerReqDto dto) {
+		careerRepository.findByIdAndPartnerId(careerId, uuid)
+				.orElseThrow(() -> new BaseException(CAREER_NOT_FOUND));
+
+		careerRepository.save(Career.builder()
+				.id(careerId)
+				.title(dto.getTitle())
+				.description(dto.getDescription())
+				.startDate(dto.getStartDate())
+				.finishDate(dto.getFinishDate())
+				.build()
+		);
+	}
+
+	@Override
+	public void deleteCareer(String uuid, Long careerId) {
+		careerRepository.deleteByIdAndPartnerId(careerId, uuid);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public CareerListRespDto getCareerList(String partnerId) {
+		return CareerListRespDto.builder()
+				.careers(careerRepository.findByPartnerId(partnerId)
+						.stream()
+						.map(CareerDto::new)
 						.toList())
 				.build();
 	}

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -7,16 +7,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.member.domain.Career;
+import com.mfc.memberservice.member.domain.PriceOption;
 import com.mfc.memberservice.member.domain.Partner;
 import com.mfc.memberservice.member.domain.Sns;
 import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.OptionReqDto;
 import com.mfc.memberservice.member.dto.req.SnsDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
 import com.mfc.memberservice.member.dto.resp.CareerDto;
 import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
+import com.mfc.memberservice.member.dto.resp.OptionDto;
+import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 import com.mfc.memberservice.member.infrastructure.CareerRepository;
+import com.mfc.memberservice.member.infrastructure.PriceOptionRepository;
 import com.mfc.memberservice.member.infrastructure.PartnerRepository;
 import com.mfc.memberservice.member.infrastructure.SnsRepository;
 
@@ -29,6 +34,7 @@ public class PartnerServiceImpl implements PartnerService {
 	private final PartnerRepository partnerRepository;
 	private final SnsRepository snsRepository;
 	private final CareerRepository careerRepository;
+	private final PriceOptionRepository optionsRepository;
 
 	@Override
 	public void updateProfileImage(String uuid, ModifyPartnerReqDto dto) {
@@ -108,6 +114,47 @@ public class PartnerServiceImpl implements PartnerService {
 				.careers(careerRepository.findByPartnerId(partnerId)
 						.stream()
 						.map(CareerDto::new)
+						.toList())
+				.build();
+	}
+
+	@Override
+	public void createOption(String uuid, OptionReqDto dto) {
+		isExist(uuid);
+		optionsRepository.save(PriceOption.builder()
+				.partnerId(uuid)
+				.value(dto.getValue())
+				.price(dto.getPrice())
+				.description(dto.getDescription())
+				.build()
+		);
+	}
+
+	@Override
+	public void updateOption(String partnerId, Long optionId, OptionReqDto dto) {
+		PriceOption option = optionsRepository.findByIdAndPartnerId(optionId, partnerId)
+				.orElseThrow(() -> new BaseException(OPTION_NOT_FOUND));
+
+		optionsRepository.save(PriceOption.builder()
+				.id(optionId)
+				.value(dto.getValue())
+				.price(dto.getPrice())
+				.description(dto.getDescription())
+				.build()
+		);
+	}
+
+	@Override
+	public void deleteOption(String partnerId, Long optionId) {
+		optionsRepository.deleteOption(partnerId, optionId);
+	}
+
+	@Override
+	public OptionListRespDto getOptionList(String partnerId) {
+		return OptionListRespDto.builder()
+				.options(optionsRepository.findByPartnerId(partnerId)
+						.stream()
+						.map(OptionDto::new)
 						.toList())
 				.build();
 	}

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -7,9 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.member.domain.Partner;
-import com.mfc.memberservice.member.domain.User;
+import com.mfc.memberservice.member.domain.Sns;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.SnsDto;
+import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
+import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 import com.mfc.memberservice.member.infrastructure.PartnerRepository;
+import com.mfc.memberservice.member.infrastructure.SnsRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class PartnerServiceImpl implements PartnerService {
 	private final PartnerRepository partnerRepository;
+	private final SnsRepository snsRepository;
 
 	@Override
 	public void updateProfileImage(String uuid, ModifyPartnerReqDto dto) {
@@ -32,6 +37,29 @@ public class PartnerServiceImpl implements PartnerService {
 				.account(partner.getAccount())
 				.average_date(partner.getAverage_date())
 				.build());
+	}
+
+	@Override
+	public void updateSns(String uuid, UpdateSnsReqDto dto) {
+		snsRepository.deleteByPartnerId(uuid);
+		dto.getSns()
+				.forEach(sns -> snsRepository.save(Sns.builder()
+						.type(sns.getType())
+						.partnerId(uuid)
+						.snsUrl(sns.getSnsUrl())
+						.build())
+				);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public SnsListRespDto getSnsList(String partnerId) {
+		return SnsListRespDto.builder()
+				.sns(snsRepository.findByPartnerId(partnerId)
+						.stream()
+						.map(SnsDto::new)
+						.toList())
+				.build();
 	}
 
 	private Partner isExist(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/domain/Career.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/Career.java
@@ -1,0 +1,40 @@
+package com.mfc.memberservice.member.domain;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Career {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(updatable = false, nullable = false)
+	private String partnerId;
+	@Column(length = 50, nullable = false)
+	private String title;
+	@Column(length = 100)
+	private String description;
+	private LocalDate startDate;
+	private LocalDate finishDate;
+
+	@Builder
+	public Career(Long id, String partnerId, String title, String description, LocalDate startDate,
+			LocalDate finishDate) {
+		this.id = id;
+		this.partnerId = partnerId;
+		this.title = title;
+		this.description = description;
+		this.startDate = startDate;
+		this.finishDate = finishDate;
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/domain/PriceOption.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/PriceOption.java
@@ -1,0 +1,36 @@
+package com.mfc.memberservice.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class PriceOption {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(nullable = false, updatable = false)
+	private String partnerId;
+	@Column(nullable = false, length = 50)
+	private String value;
+	@Column(nullable = false)
+	private Integer price;
+	@Column(length = 100)
+	private String description;
+
+	@Builder
+	public PriceOption(Long id, String partnerId, String value, Integer price, String description) {
+		this.id = id;
+		this.partnerId = partnerId;
+		this.value = value;
+		this.price = price;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/domain/Sns.java
+++ b/src/main/java/com/mfc/memberservice/member/domain/Sns.java
@@ -1,0 +1,32 @@
+package com.mfc.memberservice.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Sns {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Column(updatable = false)
+	private String partnerId;
+	@Column(length = 50)
+	private String type;
+	private String snsUrl;
+
+	@Builder
+	public Sns(Long id, String partnerId, String type, String snsUrl) {
+		this.id = id;
+		this.partnerId = partnerId;
+		this.type = type;
+		this.snsUrl = snsUrl;
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/CareerReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/CareerReqDto.java
@@ -1,0 +1,14 @@
+package com.mfc.memberservice.member.dto.req;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CareerReqDto {
+	private String title;
+	private LocalDate startDate;
+	private LocalDate finishDate;
+	private String description;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/ModifyPartnerReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/ModifyPartnerReqDto.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyPartnerReqDto {
+	private String profileImage;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/OptionReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/OptionReqDto.java
@@ -1,0 +1,10 @@
+package com.mfc.memberservice.member.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class OptionReqDto {
+	private String value;
+	private Integer price;
+	private String description;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/SnsDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/SnsDto.java
@@ -1,0 +1,16 @@
+package com.mfc.memberservice.member.dto.req;
+
+import com.mfc.memberservice.member.domain.Sns;
+
+import lombok.Getter;
+
+@Getter
+public class SnsDto {
+	private String type;
+	private String snsUrl;
+
+	public SnsDto(Sns sns) {
+		this.type = sns.getType();
+		this.snsUrl = sns.getSnsUrl();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/req/UpdateSnsReqDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/req/UpdateSnsReqDto.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.dto.req;
+
+import java.util.List;
+
+import com.mfc.memberservice.member.vo.req.SnsVo;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateSnsReqDto {
+	private List<SnsVo> sns;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/CareerDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/CareerDto.java
@@ -1,0 +1,24 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import java.time.LocalDate;
+
+import com.mfc.memberservice.member.domain.Career;
+
+import lombok.Getter;
+
+@Getter
+public class CareerDto {
+	private Long careerId;
+	private String title;
+	private String description;
+	private LocalDate startDate;
+	private LocalDate finishDate;
+
+	public CareerDto(Career career) {
+		this.careerId = career.getId();
+		this.title = career.getTitle();
+		this.description = career.getDescription();
+		this.startDate = career.getStartDate();
+		this.finishDate = career.getFinishDate();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/CareerListRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/CareerListRespDto.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CareerListRespDto {
+	private List<CareerDto> careers;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/OptionDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/OptionDto.java
@@ -1,0 +1,22 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import javax.swing.text.html.Option;
+
+import com.mfc.memberservice.member.domain.PriceOption;
+
+import lombok.Getter;
+
+@Getter
+public class OptionDto {
+	private Long optionId;
+	private String value;
+	private Integer price;
+	private String description;
+
+	public OptionDto(PriceOption option) {
+		this.optionId = option.getId();
+		this.value = option.getValue();
+		this.price = option.getPrice();
+		this.description = option.getDescription();
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/OptionListRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/OptionListRespDto.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OptionListRespDto {
+	private List<OptionDto> options;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/SnsListRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/SnsListRespDto.java
@@ -1,0 +1,14 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import java.util.List;
+
+import com.mfc.memberservice.member.dto.req.SnsDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SnsListRespDto {
+	private List<SnsDto> sns;
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/CareerRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/CareerRepository.java
@@ -1,0 +1,21 @@
+package com.mfc.memberservice.member.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mfc.memberservice.member.domain.Career;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+	Optional<Career> findByIdAndPartnerId(Long id, String partnerId);
+	List<Career> findByPartnerId(String partnerId);
+
+	@Modifying(flushAutomatically = true)
+	@Query("delete from Career c where c.id = :id and c.partnerId = :partnerId")
+	void deleteByIdAndPartnerId(@Param("id") Long id, @Param("partnerId") String partnerId);
+
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/PriceOptionRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/PriceOptionRepository.java
@@ -1,0 +1,20 @@
+package com.mfc.memberservice.member.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mfc.memberservice.member.domain.PriceOption;
+
+public interface PriceOptionRepository extends JpaRepository<PriceOption, Long> {
+	Optional<PriceOption> findByIdAndPartnerId(Long id, String partnerId);
+	List<PriceOption> findByPartnerId(String partnerId);
+
+	@Modifying(flushAutomatically = true)
+	@Query("delete from PriceOption o where o.partnerId = :partnerId and o.id = :id")
+	void deleteOption(@Param("partnerId") String partnerId, @Param("id") Long id);
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/SnsRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/SnsRepository.java
@@ -1,0 +1,18 @@
+package com.mfc.memberservice.member.infrastructure;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.mfc.memberservice.member.domain.Sns;
+
+public interface SnsRepository extends JpaRepository<Sns, Long> {
+	List<Sns> findByPartnerId(String partnerId);
+
+	@Modifying(flushAutomatically = true)
+	@Query("delete from Sns s where s.partnerId = :uuid")
+	void deleteByPartnerId(@Param("uuid") String uuid);
+}

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -1,0 +1,48 @@
+package com.mfc.memberservice.member.presentation;
+
+import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mfc.memberservice.common.exception.BaseException;
+import com.mfc.memberservice.common.response.BaseResponse;
+import com.mfc.memberservice.member.application.PartnerService;
+import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.vo.req.ModifyPartnerReqVo;
+import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/partners")
+@RequiredArgsConstructor
+@Tag(name = "partners", description = "파트너 서비스 컨트롤러")
+public class PartnerController {
+	private final PartnerService partnerService;
+	private final ModelMapper modelMapper;
+
+	@PutMapping("/profileimage")
+	@Operation(summary = "파트너 프로필 사진 수정 API", description = "profileImage만 수정 가능")
+	public BaseResponse<Void> updateProfileImage(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody ModifyPartnerReqVo vo) {
+		checkUuid(uuid);
+		partnerService.updateProfileImage(uuid, modelMapper.map(vo, ModifyPartnerReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	private void checkUuid(String uuid) {
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+	}
+}

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -4,6 +4,9 @@ import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -14,9 +17,10 @@ import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.application.PartnerService;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
-import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
 import com.mfc.memberservice.member.vo.req.ModifyPartnerReqVo;
-import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+import com.mfc.memberservice.member.vo.req.UpdateSnsReqVo;
+import com.mfc.memberservice.member.vo.resp.SnsListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,6 +42,23 @@ public class PartnerController {
 		checkUuid(uuid);
 		partnerService.updateProfileImage(uuid, modelMapper.map(vo, ModifyPartnerReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@PostMapping("/sns")
+	@Operation(summary = "파트너 SNS 등록 API", description = "파트너 포트폴리오 : sns 등록")
+	public BaseResponse<Void> updateSns(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody UpdateSnsReqVo vo) {
+		checkUuid(uuid);
+		partnerService.updateSns(uuid, modelMapper.map(vo, UpdateSnsReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@GetMapping("/sns/{partnerId}")
+	@Operation(summary = "파트너 SNS 조회 API", description = "파트너 포트폴리오 : sns 목록 조회")
+	public BaseResponse<SnsListRespVo> updateSns(@PathVariable String partnerId) {
+		return new BaseResponse<>(modelMapper.map(
+				partnerService.getSnsList(partnerId), SnsListRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -4,6 +4,8 @@ import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,10 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.application.PartnerService;
+import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
+import com.mfc.memberservice.member.vo.req.CareerReqVo;
 import com.mfc.memberservice.member.vo.req.ModifyPartnerReqVo;
 import com.mfc.memberservice.member.vo.req.UpdateSnsReqVo;
+import com.mfc.memberservice.member.vo.resp.CareerListRespVo;
 import com.mfc.memberservice.member.vo.resp.SnsListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -59,6 +64,41 @@ public class PartnerController {
 	public BaseResponse<SnsListRespVo> updateSns(@PathVariable String partnerId) {
 		return new BaseResponse<>(modelMapper.map(
 				partnerService.getSnsList(partnerId), SnsListRespVo.class));
+	}
+
+	@PostMapping("/career")
+	@Operation(summary = "파트너 경력 등록 API", description = "파트너 포트폴리오 : 경력 등록")
+	public BaseResponse<Void> createCareer(
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated CareerReqVo vo) {
+		checkUuid(uuid);
+		partnerService.createCareer(uuid, modelMapper.map(vo, CareerReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/career/{careerId}")
+	@Operation(summary = "파트너 경력 수정 API", description = "파트너 포트폴리오 : 경력 수정")
+	public BaseResponse<Void> modifyCareer(@PathVariable Long careerId,
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated CareerReqVo vo) {
+		checkUuid(uuid);
+		partnerService.updateCareer(uuid, careerId, modelMapper.map(vo, CareerReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@DeleteMapping("/career/{careerId}")
+	@Operation(summary = "파트너 경력 삭제 API", description = "파트너 포트폴리오 : 경력 삭제")
+	public BaseResponse<Void> deleteCareer(@PathVariable Long careerId,
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid) {
+		checkUuid(uuid);
+		partnerService.deleteCareer(uuid, careerId);
+		return new BaseResponse<>();
+	}
+
+	@GetMapping("/career/{partnerId}")
+	@Operation(summary = "파트너 경력 조회 API", description = "파트너 포트폴리오 : 경력 목록 조회")
+	public BaseResponse<CareerListRespVo> getCareerList(@PathVariable String partnerId) {
+		return new BaseResponse<>(modelMapper.map(partnerService.getCareerList(partnerId), CareerListRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -20,11 +20,14 @@ import com.mfc.memberservice.common.response.BaseResponse;
 import com.mfc.memberservice.member.application.PartnerService;
 import com.mfc.memberservice.member.dto.req.CareerReqDto;
 import com.mfc.memberservice.member.dto.req.ModifyPartnerReqDto;
+import com.mfc.memberservice.member.dto.req.OptionReqDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
 import com.mfc.memberservice.member.vo.req.CareerReqVo;
 import com.mfc.memberservice.member.vo.req.ModifyPartnerReqVo;
+import com.mfc.memberservice.member.vo.req.OptionReqVo;
 import com.mfc.memberservice.member.vo.req.UpdateSnsReqVo;
 import com.mfc.memberservice.member.vo.resp.CareerListRespVo;
+import com.mfc.memberservice.member.vo.resp.OptionListRespVo;
 import com.mfc.memberservice.member.vo.resp.SnsListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -99,6 +102,41 @@ public class PartnerController {
 	@Operation(summary = "파트너 경력 조회 API", description = "파트너 포트폴리오 : 경력 목록 조회")
 	public BaseResponse<CareerListRespVo> getCareerList(@PathVariable String partnerId) {
 		return new BaseResponse<>(modelMapper.map(partnerService.getCareerList(partnerId), CareerListRespVo.class));
+	}
+
+	@PostMapping("/option")
+	@Operation(summary = "파트너 옵션 등록 API", description = "파트너 포트폴리오 : 옵션 등록")
+	public BaseResponse<Void> createOption(
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated OptionReqVo vo) {
+		checkUuid(uuid);
+		partnerService.createOption(uuid, modelMapper.map(vo, OptionReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/option/{optionId}")
+	@Operation(summary = "파트너 옵션 수정 API", description = "파트너 포트폴리오 : 옵션 수정")
+	public BaseResponse<Void> modifyOption(@PathVariable Long optionId,
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated OptionReqVo vo) {
+		checkUuid(uuid);
+		partnerService.updateOption(uuid, optionId, modelMapper.map(vo, OptionReqDto.class));
+		return new BaseResponse<>();
+	}
+
+	@DeleteMapping("/option/{optionId}")
+	@Operation(summary = "파트너 옵션 삭제 API", description = "파트너 포트폴리오 : 옵션 삭제")
+	public BaseResponse<Void> deleteOption(@PathVariable Long optionId,
+			@RequestHeader(value = "UUID", defaultValue = "") String uuid) {
+		checkUuid(uuid);
+		partnerService.deleteOption(uuid, optionId);
+		return new BaseResponse<>();
+	}
+
+	@GetMapping("/option/{partnerId}")
+	@Operation(summary = "파트너 가격 옵션 조회 API", description = "파트너 포트폴리오 : 가격 옵션 조회")
+	public BaseResponse<OptionListRespVo> getOptionList(@PathVariable String partnerId) {
+		return new BaseResponse<>(modelMapper.map(partnerService.getOptionList(partnerId), OptionListRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/vo/req/CareerReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/CareerReqVo.java
@@ -1,0 +1,15 @@
+package com.mfc.memberservice.member.vo.req;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CareerReqVo {
+	@NotBlank
+	private String title;
+	private LocalDate startDate;
+	private LocalDate finishDate;
+	private String description;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/ModifyPartnerReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/ModifyPartnerReqVo.java
@@ -1,0 +1,8 @@
+package com.mfc.memberservice.member.vo.req;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyPartnerReqVo {
+	private String profileImage;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/OptionReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/OptionReqVo.java
@@ -1,0 +1,14 @@
+package com.mfc.memberservice.member.vo.req;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class OptionReqVo {
+	@NotBlank
+	private String value;
+	@Min(value = 0)
+	private Integer price;
+	private String description;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/SnsVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/SnsVo.java
@@ -1,0 +1,9 @@
+package com.mfc.memberservice.member.vo.req;
+
+import lombok.Getter;
+
+@Getter
+public class SnsVo {
+	private String type;
+	private String snsUrl;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/req/UpdateSnsReqVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/req/UpdateSnsReqVo.java
@@ -1,0 +1,10 @@
+package com.mfc.memberservice.member.vo.req;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateSnsReqVo {
+	private List<SnsVo> sns;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/CareerListRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/CareerListRespVo.java
@@ -1,0 +1,10 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class CareerListRespVo {
+	private List<CareerVo> careers;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/CareerVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/CareerVo.java
@@ -1,0 +1,14 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import java.time.LocalDate;
+
+import lombok.Getter;
+
+@Getter
+public class CareerVo {
+	private Long careerId;
+	private String title;
+	private String description;
+	private LocalDate startDate;
+	private LocalDate finishDate;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/OptionListRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/OptionListRespVo.java
@@ -1,0 +1,10 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class OptionListRespVo {
+	private List<OptionVO> options;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/OptionVO.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/OptionVO.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class OptionVO {
+	private Long optionId;
+	private String value;
+	private Integer price;
+	private String description;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/SnsListRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/SnsListRespVo.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import java.util.List;
+
+import com.mfc.memberservice.member.vo.req.SnsVo;
+
+import lombok.Getter;
+
+@Getter
+public class SnsListRespVo {
+	private List<SnsVo> sns;
+}


### PR DESCRIPTION
## 📣파트너 포트폴리오 관련 API 구현 (1)
### 📅 2024.05.27
 
 ### 🌵Branch
`feature/partner`  → `develop`

### 📢 Description
 - 파트너 프로필 이미지 수정
 - 파트너 경력 등록/수정/삭제/조회
 - 파트너 가격 등록/수정/삭제/조회
 - 파트너 sns 등록/조회

### 💬Issue Number
[#11] - 파트너 포트폴리오 (1)

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
- 포트폴리오 관련 API가 너무 많아서 1차, 2차로 나눠서 진행하겠읍니다,,
