### PR TITLE
회원 프로필 관련 API 추가 구현 + 버그 수정

### DIFF
--- a/src/main/java/com/mfc/memberservice/member/application/MemberService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberService.java
@@ -7,7 +7,6 @@ import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.dto.resp.SignInRespDto;
 
 public interface MemberService {
-	ProfileRespDto getProfile(String uuid, String role);
 	void modifyNickname(String uuid, String role, String nickname);
 	void modifyPassword(String uuid, ModifyMemberReqDto dto);
 	void modifyFavoriteStyle(String uuid, ModifyFavoriteStyleReqDto dto);

--- a/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/MemberServiceImpl.java
@@ -39,26 +39,6 @@ public class MemberServiceImpl implements MemberService {
 	private final JwtTokenProvider tokenProvider;
 
 	@Override
-	@Transactional(readOnly = true)
-	public ProfileRespDto getProfile(String uuid, String role) {
-		ProfileRespDto profile = null;
-
-		if(role.equals("USER")) {
-			profile = memberRepository.getUserProfile(uuid);
-		} else if(role.equals("PARTNER")) {
-			profile = memberRepository.getPartnerProfile(uuid);
-		} else {
-			throw new BaseException(NO_EXIT_ROLE);
-		}
-
-		if(profile == null) {
-			throw new BaseException(MEMBER_NOT_FOUND);
-		}
-
-		return profile;
-	}
-
-	@Override
 	public void modifyNickname(String uuid, String role, String nickname) {
 		if(role.equals("USER")) {
 			User user = userRepository.findByUuid(uuid)

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -8,6 +8,7 @@ import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
 import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerAccountRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerPortfolioRespDto;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 
 public interface PartnerService {
@@ -29,4 +30,5 @@ public interface PartnerService {
 	void updateAveragePrice(String uuid, ModifyPartnerReqDto dto);
 	PartnerPortfolioRespDto getPortfolio(String partnerId);
 	PartnerAccountRespDto getAccount(String partnerId);
+	ProfileRespDto getProfile(String partnerId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerService.java
@@ -6,6 +6,7 @@ import com.mfc.memberservice.member.dto.req.OptionReqDto;
 import com.mfc.memberservice.member.dto.req.UpdateSnsReqDto;
 import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
 import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
+import com.mfc.memberservice.member.dto.resp.PartnerAccountRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerPortfolioRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 
@@ -27,4 +28,5 @@ public interface PartnerService {
 	void updateChatTime(String uuid, ModifyPartnerReqDto dto);
 	void updateAveragePrice(String uuid, ModifyPartnerReqDto dto);
 	PartnerPortfolioRespDto getPortfolio(String partnerId);
+	PartnerAccountRespDto getAccount(String partnerId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -18,6 +18,7 @@ import com.mfc.memberservice.member.dto.resp.CareerDto;
 import com.mfc.memberservice.member.dto.resp.CareerListRespDto;
 import com.mfc.memberservice.member.dto.resp.OptionDto;
 import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
+import com.mfc.memberservice.member.dto.resp.PartnerAccountRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerPortfolioRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
@@ -264,8 +265,7 @@ public class PartnerServiceImpl implements PartnerService {
 	@Override
 	@Transactional(readOnly = true)
 	public PartnerPortfolioRespDto getPortfolio(String partnerId) {
-		Partner partner = partnerRepository.findByUuid(partnerId)
-				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+		Partner partner = isExist(partnerId);
 
 		return PartnerPortfolioRespDto.builder()
 				.description(partner.getDescription())
@@ -273,6 +273,16 @@ public class PartnerServiceImpl implements PartnerService {
 				.endTime(partner.getEndTime())
 				.averageDate(partner.getAverageDate())
 				.averagePrice(partner.getAveragePrice())
+				.build();
+	}
+
+	@Override
+	public PartnerAccountRespDto getAccount(String partnerId) {
+		Partner partner = isExist(partnerId);
+
+		return PartnerAccountRespDto.builder()
+				.bank(partner.getBank())
+				.account(partner.getAccount())
 				.build();
 	}
 

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -272,6 +272,7 @@ public class PartnerServiceImpl implements PartnerService {
 				.startTime(partner.getStartTime())
 				.endTime(partner.getEndTime())
 				.averageDate(partner.getAverageDate())
+				.averagePrice(partner.getAveragePrice())
 				.build();
 	}
 

--- a/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/PartnerServiceImpl.java
@@ -20,6 +20,7 @@ import com.mfc.memberservice.member.dto.resp.OptionDto;
 import com.mfc.memberservice.member.dto.resp.OptionListRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerAccountRespDto;
 import com.mfc.memberservice.member.dto.resp.PartnerPortfolioRespDto;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.dto.resp.SnsDto;
 import com.mfc.memberservice.member.dto.resp.SnsListRespDto;
 import com.mfc.memberservice.member.infrastructure.CareerRepository;
@@ -283,6 +284,17 @@ public class PartnerServiceImpl implements PartnerService {
 		return PartnerAccountRespDto.builder()
 				.bank(partner.getBank())
 				.account(partner.getAccount())
+				.build();
+	}
+
+	@Override
+	public ProfileRespDto getProfile(String partnerId) {
+		Partner partner = isExist(partnerId);
+
+		return ProfileRespDto.builder()
+				.nickname(partner.getNickname())
+				.profileImage(partner.getProfileImage())
+				.imageAlt(partner.getImageAlt())
 				.build();
 	}
 

--- a/src/main/java/com/mfc/memberservice/member/application/UserService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserService.java
@@ -1,7 +1,9 @@
 package com.mfc.memberservice.member.application;
 
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.resp.BodyTypeRespDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+import com.mfc.memberservice.member.dto.resp.SizeRespDto;
 import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 
 public interface UserService {
@@ -10,4 +12,6 @@ public interface UserService {
 	void updateProfileImage(String uuid, ModifyUserReqDto dto);
 	void updateBodyType(String uuid, ModifyUserReqDto dto);
 	ProfileRespDto getProfile(String userId);
+	BodyTypeRespDto getBodyType(String userId);
+	SizeRespDto getSize(String userId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/UserService.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserService.java
@@ -1,6 +1,7 @@
 package com.mfc.memberservice.member.application;
 
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
 
 public interface UserService {
@@ -8,4 +9,5 @@ public interface UserService {
 	void updateSize(String uuid, ModifyUserReqDto dto);
 	void updateProfileImage(String uuid, ModifyUserReqDto dto);
 	void updateBodyType(String uuid, ModifyUserReqDto dto);
+	ProfileRespDto getProfile(String userId);
 }

--- a/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.member.domain.User;
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 import com.mfc.memberservice.member.infrastructure.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -92,6 +93,17 @@ public class UserServiceImpl implements UserService {
 				.bodyType(dto.getBodyType()) // 수정
 				.build()
 		);
+	}
+
+	@Override
+	public ProfileRespDto getProfile(String userId) {
+		User user = isExist(userId);
+
+		return ProfileRespDto.builder()
+				.nickname(user.getNickname())
+				.profileImage(user.getProfileImage())
+				.imageAlt(user.getImageAlt())
+				.build();
 	}
 
 	private User isExist(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/application/UserServiceImpl.java
@@ -8,7 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.mfc.memberservice.common.exception.BaseException;
 import com.mfc.memberservice.member.domain.User;
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
+import com.mfc.memberservice.member.dto.resp.BodyTypeRespDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
+import com.mfc.memberservice.member.dto.resp.SizeRespDto;
 import com.mfc.memberservice.member.infrastructure.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -103,6 +105,28 @@ public class UserServiceImpl implements UserService {
 				.nickname(user.getNickname())
 				.profileImage(user.getProfileImage())
 				.imageAlt(user.getImageAlt())
+				.build();
+	}
+
+	@Override
+	public BodyTypeRespDto getBodyType(String userId) {
+		User user = isExist(userId);
+
+		return BodyTypeRespDto.builder()
+				.height(user.getHeight())
+				.weight(user.getWeight())
+				.bodyType(user.getBodyType() == null ? null : user.getBodyType().toString())
+				.build();
+	}
+
+	@Override
+	public SizeRespDto getSize(String userId) {
+		User user = isExist(userId);
+
+		return SizeRespDto.builder()
+				.topSize(user.getTopSize() == null ? null : user.getTopSize().toString())
+				.bottomSize(user.getBottomSize() == null ? null : user.getBottomSize().toString())
+				.shoeSize(user.getShoeSize())
 				.build();
 	}
 

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/BodyTypeRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/BodyTypeRespDto.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BodyTypeRespDto {
+	private Integer height;
+	private Integer weight;
+	private String bodyType;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/PartnerAccountRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/PartnerAccountRespDto.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PartnerAccountRespDto {
+	private String bank;
+	private String account;
+}

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/ProfileRespDto.java
@@ -1,13 +1,12 @@
 package com.mfc.memberservice.member.dto.resp;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class ProfileRespDto {
+	private String nickname;
 	private String profileImage;
 	private String imageAlt;
-	private String nickname;
-	private String email;
 }

--- a/src/main/java/com/mfc/memberservice/member/dto/resp/SizeRespDto.java
+++ b/src/main/java/com/mfc/memberservice/member/dto/resp/SizeRespDto.java
@@ -1,0 +1,12 @@
+package com.mfc.memberservice.member.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SizeRespDto {
+	private String topSize;
+	private String bottomSize;
+	private Integer shoeSize;
+}

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/CustomRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/CustomRepository.java
@@ -9,7 +9,5 @@ import com.mfc.memberservice.member.dto.resp.FavoriteStyleRespDto;
 import com.mfc.memberservice.member.dto.resp.ProfileRespDto;
 
 public interface CustomRepository {
-	ProfileRespDto getUserProfile(String uuid);
-	ProfileRespDto getPartnerProfile(String uuid);
 	List<FavoriteStyleDto> getFavoriteStyles(String uuid);
 }

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/CustomRepositoryImpl.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/CustomRepositoryImpl.java
@@ -21,38 +21,6 @@ public class CustomRepositoryImpl implements CustomRepository {
 	private final JPAQueryFactory query;
 
 	@Override
-	public ProfileRespDto getUserProfile(String uuid) {
-		return query
-				.select(Projections.constructor(ProfileRespDto.class,
-						user.profileImage.as("profileImage"),
-						user.imageAlt.as("imageAlt"),
-						user.nickname.as("nickname"),
-						member.email.as("email")
-				))
-				.from(user)
-				.join(member)
-				.on(user.uuid.eq(member.uuid))
-				.where(user.uuid.eq(uuid))
-				.fetchOne();
-	}
-
-	@Override
-	public ProfileRespDto getPartnerProfile(String uuid) {
-		return query
-				.select(Projections.constructor(ProfileRespDto.class,
-						partner.profileImage.as("profileImage"),
-						partner.imageAlt.as("imageAlt"),
-						partner.nickname.as("nickname"),
-						member.email.as("email")
-				))
-				.from(partner)
-				.join(member)
-				.on(partner.uuid.eq(member.uuid))
-				.where(partner.uuid.eq(uuid))
-				.fetchOne();
-	}
-
-	@Override
 	public List<FavoriteStyleDto> getFavoriteStyles(String uuid) {
 		return query
 				.select(Projections.constructor(FavoriteStyleDto.class,

--- a/src/main/java/com/mfc/memberservice/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/mfc/memberservice/member/infrastructure/MemberRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.mfc.memberservice.member.domain.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long>, CustomRepository {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 	@Query("Select m from Member m where m.status = 1 and  m.phone = :phone")
 	Optional<Member> findByActivePhone(@Param("phone") String phone);
 

--- a/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/MemberController.java
@@ -39,19 +39,6 @@ public class MemberController {
 	private final MemberService memberService;
 	private final ModelMapper modelMapper;
 
-	@GetMapping
-	@Operation(summary = "회원 기본 프로필 조회 API", description = "헤더의 ROLE 값으로 구분하여 역할에 따른 프로필 조회")
-	public BaseResponse<ProfileRespVo> getProfile(
-			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
-			@RequestHeader(name = "Role", defaultValue = "") String role) {
-		if(!StringUtils.hasText(uuid) || !StringUtils.hasText(role)) {
-			throw new BaseException(NO_REQUIRED_HEADER);
-		}
-
-		return new BaseResponse<>(modelMapper.map(
-				memberService.getProfile(uuid, role), ProfileRespVo.class));
-	}
-
 	@PutMapping("/nickname")
 	@Operation(summary = "닉네임 수정 API", description = "헤더의 ROLE 값으로 구분하여 역할에 따라 닉네임 수정")
 	public BaseResponse<Void> modifyNickname(

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -28,6 +28,7 @@ import com.mfc.memberservice.member.vo.req.OptionReqVo;
 import com.mfc.memberservice.member.vo.req.UpdateSnsReqVo;
 import com.mfc.memberservice.member.vo.resp.CareerListRespVo;
 import com.mfc.memberservice.member.vo.resp.OptionListRespVo;
+import com.mfc.memberservice.member.vo.resp.PartnerAccountRespVo;
 import com.mfc.memberservice.member.vo.resp.PartnerPortfolioRespVo;
 import com.mfc.memberservice.member.vo.resp.SnsListRespVo;
 
@@ -192,13 +193,23 @@ public class PartnerController {
 		return new BaseResponse<>();
 	}
 
-	@GetMapping()
+	@GetMapping
 	@Operation(summary = "파트너 포트폴리오 조회 API", description = "한 줄 소개, 채팅 가능 시간, 평균 소요 기간 조회")
 	public BaseResponse<PartnerPortfolioRespVo> getPortfolio(
 			@RequestHeader(value = "partnerId", defaultValue = "") String partnerId) {
 		return new BaseResponse<>(modelMapper.map(
 				partnerService.getPortfolio(partnerId), PartnerPortfolioRespVo.class));
 	}
+
+	@GetMapping("/account")
+	@Operation(summary = "파트너 계좌 정보 조회 API", description = "은행, 계좌정보 조회")
+	public BaseResponse<PartnerAccountRespVo> getAccount(
+			@RequestHeader(value = "UUID", defaultValue = "") String partnerId) {
+		checkUuid(partnerId);
+		return new BaseResponse<>(modelMapper.map(
+				partnerService.getAccount(partnerId), PartnerAccountRespVo.class));
+	}
+
 
 	private void checkUuid(String uuid) {
 		if(!StringUtils.hasText(uuid)) {

--- a/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/PartnerController.java
@@ -30,6 +30,7 @@ import com.mfc.memberservice.member.vo.resp.CareerListRespVo;
 import com.mfc.memberservice.member.vo.resp.OptionListRespVo;
 import com.mfc.memberservice.member.vo.resp.PartnerAccountRespVo;
 import com.mfc.memberservice.member.vo.resp.PartnerPortfolioRespVo;
+import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
 import com.mfc.memberservice.member.vo.resp.SnsListRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -210,6 +211,13 @@ public class PartnerController {
 				partnerService.getAccount(partnerId), PartnerAccountRespVo.class));
 	}
 
+	@GetMapping("/profile")
+	@Operation(summary = "파트너 기본 프로필 조회 API", description = "닉네임, 프로필 이미지 조회")
+	public BaseResponse<ProfileRespVo> getProfile(
+			@RequestHeader(value = "partnerId", defaultValue = "") String partnerId) {
+		return new BaseResponse<>(modelMapper.map(
+				partnerService.getProfile(partnerId), ProfileRespVo.class));
+	}
 
 	private void checkUuid(String uuid) {
 		if(!StringUtils.hasText(uuid)) {

--- a/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
@@ -4,6 +4,7 @@ import static com.mfc.memberservice.common.response.BaseResponseStatus.*;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,6 +17,7 @@ import com.mfc.memberservice.common.response.BaseResponseStatus;
 import com.mfc.memberservice.member.application.UserService;
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
 import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,6 +69,14 @@ public class UserController {
 		checkUuid(uuid);
 		userService.updateBodyType(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@GetMapping("/profile")
+	@Operation(summary = "유저 기본 프로필 조회 API", description = "닉네임, 프로필 이미지 조회")
+	public BaseResponse<ProfileRespVo> getProfile(
+			@RequestHeader(value = "userId", defaultValue = "") String userId) {
+		return new BaseResponse<>(modelMapper.map(
+				userService.getProfile(userId), ProfileRespVo.class));
 	}
 
 	private void checkUuid(String uuid) {

--- a/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
+++ b/src/main/java/com/mfc/memberservice/member/presentation/UserController.java
@@ -17,7 +17,9 @@ import com.mfc.memberservice.common.response.BaseResponseStatus;
 import com.mfc.memberservice.member.application.UserService;
 import com.mfc.memberservice.member.dto.req.ModifyUserReqDto;
 import com.mfc.memberservice.member.vo.req.ModifyUserReqVo;
+import com.mfc.memberservice.member.vo.resp.BodyTypeRespVo;
 import com.mfc.memberservice.member.vo.resp.ProfileRespVo;
+import com.mfc.memberservice.member.vo.resp.SizeRespVo;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,6 +53,14 @@ public class UserController {
 		return new BaseResponse<>();
 	}
 
+	@GetMapping("/size")
+	@Operation(summary = "유저 옷 사이즈 조회 API", description = "topSize, bottomSize, shoeSize 조회")
+	public BaseResponse<SizeRespVo> getSize(
+			@RequestHeader(name = "userId", defaultValue = "") String userId) {
+		return new BaseResponse<>(modelMapper.map(
+				userService.getSize(userId), SizeRespVo.class));
+	}
+
 	@PutMapping("/profileimage")
 	@Operation(summary = "유저 프로필 사진 수정 API", description = "profileImage만 수정 가능")
 	public BaseResponse<Void> updateProfileImage(
@@ -69,6 +79,14 @@ public class UserController {
 		checkUuid(uuid);
 		userService.updateBodyType(uuid, modelMapper.map(vo, ModifyUserReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@GetMapping("/bodyType")
+	@Operation(summary = "유저 체형 조회 API", description = "height, weight, bodyType 조회")
+	public BaseResponse<BodyTypeRespVo> getBodyType(
+			@RequestHeader(name = "userId", defaultValue = "") String userId) {
+		return new BaseResponse<>(modelMapper.map(
+				userService.getBodyType(userId), BodyTypeRespVo.class));
 	}
 
 	@GetMapping("/profile")

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/BodyTypeRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/BodyTypeRespVo.java
@@ -1,0 +1,11 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BodyTypeRespVo {
+	private Integer height;
+	private Integer weight;
+	private String bodyType;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/PartnerAccountRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/PartnerAccountRespVo.java
@@ -1,0 +1,9 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class PartnerAccountRespVo {
+	private String bank;
+	private String account;
+}

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/ProfileRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/ProfileRespVo.java
@@ -4,8 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class ProfileRespVo {
+	private String nickname;
 	private String profileImage;
 	private String imageAlt;
-	private String nickname;
-	private String email;
 }

--- a/src/main/java/com/mfc/memberservice/member/vo/resp/SizeRespVo.java
+++ b/src/main/java/com/mfc/memberservice/member/vo/resp/SizeRespVo.java
@@ -1,0 +1,10 @@
+package com.mfc.memberservice.member.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class SizeRespVo {
+	private String topSize;
+	private String bottomSize;
+	private Integer shoeSize;
+}


### PR DESCRIPTION
## 📣 회원 프로필 관련 API 추가 구현 + 버그 수정
### 📅 2024.06.13
 
 ### 🌵Branch
`develop`  → `feature/profile`

### 📢 Description
- 파트너 & 유저 프로필 공통 조회 API 제거
- 파트너 포트폴리오 조회 시 averagePrice가 null로 조회되는 버그 수정
- 유저 & 파트너 기본 프로필 (이미지, 닉네임) 조회 API 구현
- 파트너 정산 정보 (은행 + 계좌번호) 조회 API 구현
- 유저 체형 & 사이즈 정보 조회 API 구현

### 💬Issue Number
close #40 

### 🛠️Type
- [x] 새로운 기능 추가 
- [x] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
(참고사항을 적어주세요)
